### PR TITLE
feat: baking assignments & delivery tracking

### DIFF
--- a/src/app/api/assignments/[id]/route.ts
+++ b/src/app/api/assignments/[id]/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { isValidStatusTransition } from '@/lib/assignments'
+import type { AssignmentStatus } from '@/types/database'
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from('assignments')
+    .select(
+      '*, assigned_profile:assigned_to(display_name), creator_profile:created_by(display_name)'
+    )
+    .eq('id', id)
+    .single()
+  if (error) return NextResponse.json({ error: error.message }, { status: 404 })
+  return NextResponse.json(data)
+}
+
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const body = await request.json()
+  const updates: Record<string, unknown> = {}
+
+  for (const key of [
+    'description',
+    'due_date',
+    'delivery_destination',
+    'delivery_notes',
+    'assigned_to',
+  ]) {
+    if (body[key] !== undefined) updates[key] = body[key]
+  }
+
+  // Handle status transitions
+  if (body.status) {
+    // Fetch current status to validate transition
+    const { data: current } = (await supabase
+      .from('assignments')
+      .select('status')
+      .eq('id', id)
+      .single()) as unknown as { data: { status: AssignmentStatus } | null }
+
+    if (current && !isValidStatusTransition(current.status, body.status)) {
+      return NextResponse.json(
+        { error: `Cannot transition from ${current.status} to ${body.status}` },
+        { status: 400 }
+      )
+    }
+    updates.status = body.status
+  }
+
+  // Handle claim action
+  if (body.claim) {
+    updates.assigned_to = user.id
+    if (!body.status) updates.status = 'in_progress'
+  }
+
+  const query = supabase.from('assignments')
+  // @ts-expect-error -- Supabase v2.98 generic inference
+  const { data, error } = await query.update(updates).eq('id', id).select().single()
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data)
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { error } = await supabase.from('assignments').delete().eq('id', id)
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/assignments/route.ts
+++ b/src/app/api/assignments/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import type { TablesInsert } from '@/types/database'
+
+export async function GET(request: NextRequest) {
+  const supabase = await createClient()
+  const { searchParams } = new URL(request.url)
+  const status = searchParams.get('status')
+  const destination = searchParams.get('destination')
+  const assignee = searchParams.get('assignee')
+
+  let query = supabase
+    .from('assignments')
+    .select(
+      '*, assigned_profile:assigned_to(display_name), creator_profile:created_by(display_name)'
+    )
+    .order('due_date', { ascending: true, nullsFirst: false })
+
+  if (status) {
+    query = query.eq('status', status)
+  }
+  if (destination) {
+    query = query.eq('delivery_destination', destination)
+  }
+  if (assignee) {
+    query = query.eq('assigned_to', assignee)
+  }
+
+  const { data, error } = await query
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data)
+}
+
+export async function POST(request: NextRequest) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const body = await request.json()
+  const { description, due_date, delivery_destination, delivery_notes, assigned_to } = body
+
+  if (!description) return NextResponse.json({ error: 'Description is required' }, { status: 400 })
+
+  const row: TablesInsert<'assignments'> = {
+    description,
+    due_date: due_date || null,
+    delivery_destination: delivery_destination || null,
+    delivery_notes: delivery_notes || null,
+    assigned_to: assigned_to || null,
+    status: assigned_to ? 'in_progress' : 'open',
+    created_by: user.id,
+  }
+
+  // @ts-expect-error -- Supabase v2.98 generic inference
+  const { data, error } = await supabase.from('assignments').insert(row).select().single()
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data, { status: 201 })
+}

--- a/src/app/assignments/[id]/page.tsx
+++ b/src/app/assignments/[id]/page.tsx
@@ -1,0 +1,176 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter, useParams } from 'next/navigation'
+import { useProfile } from '@/lib/hooks/use-profile'
+import {
+  DESTINATION_LABELS,
+  STATUS_LABELS,
+  STATUS_COLORS,
+  isValidStatusTransition,
+} from '@/lib/assignments'
+import type { AssignmentStatus, DeliveryDestination } from '@/types/database'
+
+interface AssignmentDetail {
+  id: string
+  description: string
+  status: AssignmentStatus
+  due_date: string | null
+  delivery_destination: DeliveryDestination | null
+  delivery_notes: string | null
+  assigned_to: string | null
+  created_by: string | null
+  created_at: string
+  assigned_profile: { display_name: string } | null
+  creator_profile: { display_name: string } | null
+}
+
+export default function AssignmentDetailPage() {
+  const router = useRouter()
+  const params = useParams()
+  const id = params.id as string
+  const { profile, isAdmin } = useProfile()
+  const [assignment, setAssignment] = useState<AssignmentDetail | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    async function fetchAssignment() {
+      const res = await fetch(`/api/assignments/${id}`)
+      if (res.ok) setAssignment(await res.json())
+      setLoading(false)
+    }
+    fetchAssignment()
+  }, [id])
+
+  async function handleStatusChange(newStatus: AssignmentStatus) {
+    const res = await fetch(`/api/assignments/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: newStatus }),
+    })
+    if (res.ok) {
+      const updated = await res.json()
+      setAssignment((prev) => (prev ? { ...prev, ...updated } : prev))
+    }
+  }
+
+  async function handleClaim() {
+    const res = await fetch(`/api/assignments/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ claim: true }),
+    })
+    if (res.ok) {
+      const updated = await res.json()
+      setAssignment((prev) => (prev ? { ...prev, ...updated } : prev))
+    }
+  }
+
+  async function handleDelete() {
+    if (!confirm('Delete this assignment?')) return
+    const res = await fetch(`/api/assignments/${id}`, { method: 'DELETE' })
+    if (res.ok) router.push('/assignments')
+  }
+
+  if (loading) return <div className="animate-pulse text-gray-400">Loading...</div>
+  if (!assignment) return <div className="text-red-600">Assignment not found.</div>
+
+  const canDelete = isAdmin || assignment.created_by === profile?.id
+  const canClaim = assignment.status === 'open' && !assignment.assigned_to
+  const canProgress =
+    assignment.status === 'open' && isValidStatusTransition(assignment.status, 'in_progress')
+  const canComplete = isValidStatusTransition(assignment.status, 'completed')
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900">{assignment.description}</h1>
+        {canDelete && (
+          <button
+            onClick={handleDelete}
+            className="rounded-md border border-red-300 px-3 py-1.5 text-sm text-red-600 hover:bg-red-50"
+          >
+            Delete
+          </button>
+        )}
+      </div>
+
+      <div className="bg-white shadow rounded-lg p-6 space-y-4">
+        <div className="flex flex-wrap gap-3">
+          <span
+            className={`inline-block rounded-full px-3 py-1 text-sm font-medium ${STATUS_COLORS[assignment.status]}`}
+          >
+            {STATUS_LABELS[assignment.status]}
+          </span>
+          {assignment.delivery_destination && (
+            <span className="inline-block rounded-full px-3 py-1 text-sm font-medium bg-gray-100 text-gray-700">
+              {DESTINATION_LABELS[assignment.delivery_destination]}
+            </span>
+          )}
+        </div>
+
+        {assignment.due_date && (
+          <p className="text-sm text-gray-600">
+            <span className="font-medium">Due:</span>{' '}
+            {new Date(assignment.due_date).toLocaleDateString()}
+          </p>
+        )}
+
+        {assignment.assigned_profile?.display_name && (
+          <p className="text-sm text-gray-600">
+            <span className="font-medium">Assigned to:</span>{' '}
+            {assignment.assigned_profile.display_name}
+          </p>
+        )}
+
+        {assignment.creator_profile?.display_name && (
+          <p className="text-sm text-gray-600">
+            <span className="font-medium">Created by:</span>{' '}
+            {assignment.creator_profile.display_name}
+          </p>
+        )}
+
+        {assignment.delivery_notes && (
+          <div>
+            <p className="text-sm font-medium text-gray-700">Delivery Notes</p>
+            <p className="text-sm text-gray-600 whitespace-pre-wrap">{assignment.delivery_notes}</p>
+          </div>
+        )}
+
+        <div className="flex flex-wrap gap-2 pt-2 border-t">
+          {canClaim && (
+            <button
+              onClick={handleClaim}
+              className="rounded-md bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700"
+            >
+              Claim This Assignment
+            </button>
+          )}
+          {canProgress && !canClaim && (
+            <button
+              onClick={() => handleStatusChange('in_progress')}
+              className="rounded-md bg-yellow-500 px-4 py-2 text-sm font-medium text-white hover:bg-yellow-600"
+            >
+              Start Working
+            </button>
+          )}
+          {canComplete && (
+            <button
+              onClick={() => handleStatusChange('completed')}
+              className="rounded-md bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700"
+            >
+              Mark Complete
+            </button>
+          )}
+        </div>
+      </div>
+
+      <button
+        onClick={() => router.push('/assignments')}
+        className="text-sm text-brand-600 hover:underline"
+      >
+        &larr; Back to Assignments
+      </button>
+    </div>
+  )
+}

--- a/src/app/assignments/new/page.tsx
+++ b/src/app/assignments/new/page.tsx
@@ -1,0 +1,141 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useProfile } from '@/lib/hooks/use-profile'
+import { DESTINATION_LABELS } from '@/lib/assignments'
+
+export default function NewAssignmentPage() {
+  const router = useRouter()
+  const { profile } = useProfile()
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [assignToSelf, setAssignToSelf] = useState(false)
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setLoading(true)
+    setError('')
+
+    const form = new FormData(e.currentTarget)
+    const body = {
+      description: form.get('description'),
+      due_date: form.get('due_date') || null,
+      delivery_destination: form.get('delivery_destination') || null,
+      delivery_notes: form.get('delivery_notes') || null,
+      assigned_to: assignToSelf ? profile?.id : null,
+    }
+
+    const res = await fetch('/api/assignments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+
+    if (res.ok) {
+      router.push('/assignments')
+    } else {
+      const data = await res.json()
+      setError(data.error || 'Failed to create assignment')
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="max-w-lg mx-auto">
+      <h1 className="text-2xl font-bold text-gray-900 mb-6">Create Assignment</h1>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label htmlFor="description" className="block text-sm font-medium text-gray-700">
+            Description
+          </label>
+          <textarea
+            id="description"
+            name="description"
+            required
+            rows={3}
+            placeholder="e.g., Bake 12 sourdough loaves for Ruth's Cottage"
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-brand-500 focus:ring-brand-500 sm:text-sm"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="due_date" className="block text-sm font-medium text-gray-700">
+            Due Date
+          </label>
+          <input
+            id="due_date"
+            name="due_date"
+            type="date"
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-brand-500 focus:ring-brand-500 sm:text-sm"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="delivery_destination" className="block text-sm font-medium text-gray-700">
+            Delivery Destination
+          </label>
+          <select
+            id="delivery_destination"
+            name="delivery_destination"
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-brand-500 focus:ring-brand-500 sm:text-sm"
+          >
+            <option value="">Select destination...</option>
+            {Object.entries(DESTINATION_LABELS).map(([key, label]) => (
+              <option key={key} value={key}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label htmlFor="delivery_notes" className="block text-sm font-medium text-gray-700">
+            Delivery Notes
+          </label>
+          <textarea
+            id="delivery_notes"
+            name="delivery_notes"
+            rows={2}
+            placeholder="Special instructions, contact info, etc."
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-brand-500 focus:ring-brand-500 sm:text-sm"
+          />
+        </div>
+
+        <label className="flex items-center gap-2 text-sm text-gray-700">
+          <input
+            type="checkbox"
+            checked={assignToSelf}
+            onChange={(e) => setAssignToSelf(e.target.checked)}
+            className="rounded border-gray-300"
+          />
+          Assign to myself
+        </label>
+
+        {error && (
+          <div className="rounded-md bg-red-50 p-3">
+            <p className="text-sm text-red-700">{error}</p>
+          </div>
+        )}
+
+        <div className="flex gap-3">
+          <button
+            type="submit"
+            disabled={loading}
+            className="rounded-md bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700 disabled:opacity-50"
+          >
+            {loading ? 'Creating...' : 'Create Assignment'}
+          </button>
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/src/app/assignments/page.tsx
+++ b/src/app/assignments/page.tsx
@@ -1,8 +1,152 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { useProfile } from '@/lib/hooks/use-profile'
+import { DESTINATION_LABELS, STATUS_LABELS, STATUS_COLORS } from '@/lib/assignments'
+import type { AssignmentStatus, DeliveryDestination } from '@/types/database'
+
+interface AssignmentRow {
+  id: string
+  description: string
+  status: AssignmentStatus
+  due_date: string | null
+  delivery_destination: DeliveryDestination | null
+  assigned_to: string | null
+  created_by: string | null
+  assigned_profile: { display_name: string } | null
+  creator_profile: { display_name: string } | null
+}
+
 export default function AssignmentsPage() {
+  const { profile } = useProfile()
+  const [assignments, setAssignments] = useState<AssignmentRow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [statusFilter, setStatusFilter] = useState<string>('')
+  const [destFilter, setDestFilter] = useState<string>('')
+  const [showMine, setShowMine] = useState(false)
+
+  useEffect(() => {
+    async function fetchAssignments() {
+      const params = new URLSearchParams()
+      if (statusFilter) params.set('status', statusFilter)
+      if (destFilter) params.set('destination', destFilter)
+      if (showMine && profile?.id) params.set('assignee', profile.id)
+      const res = await fetch(`/api/assignments?${params}`)
+      if (res.ok) setAssignments(await res.json())
+      setLoading(false)
+    }
+    fetchAssignments()
+  }, [statusFilter, destFilter, showMine, profile?.id])
+
+  async function handleClaim(id: string) {
+    const res = await fetch(`/api/assignments/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ claim: true }),
+    })
+    if (res.ok) {
+      setAssignments((prev) =>
+        prev.map((a) =>
+          a.id === id ? { ...a, status: 'in_progress', assigned_to: profile?.id ?? null } : a
+        )
+      )
+    }
+  }
+
   return (
-    <div>
-      <h1 className="text-2xl font-bold text-gray-900 mb-4">Assignments</h1>
-      <p className="text-gray-600">Baker assignments and scheduling coming soon.</p>
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900">Assignments</h1>
+        <Link
+          href="/assignments/new"
+          className="rounded-md bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700"
+        >
+          Create Assignment
+        </Link>
+      </div>
+
+      <div className="flex flex-wrap gap-3">
+        <select
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value)}
+          className="rounded-md border border-gray-300 px-3 py-1.5 text-sm"
+        >
+          <option value="">All Statuses</option>
+          <option value="open">Open</option>
+          <option value="in_progress">In Progress</option>
+          <option value="completed">Completed</option>
+        </select>
+
+        <select
+          value={destFilter}
+          onChange={(e) => setDestFilter(e.target.value)}
+          className="rounded-md border border-gray-300 px-3 py-1.5 text-sm"
+        >
+          <option value="">All Destinations</option>
+          {Object.entries(DESTINATION_LABELS).map(([key, label]) => (
+            <option key={key} value={key}>
+              {label}
+            </option>
+          ))}
+        </select>
+
+        <label className="flex items-center gap-2 text-sm text-gray-700">
+          <input
+            type="checkbox"
+            checked={showMine}
+            onChange={(e) => setShowMine(e.target.checked)}
+            className="rounded border-gray-300"
+          />
+          My assignments only
+        </label>
+      </div>
+
+      {loading ? (
+        <div className="animate-pulse text-gray-400">Loading...</div>
+      ) : assignments.length === 0 ? (
+        <p className="text-gray-500 text-center py-8">No assignments found.</p>
+      ) : (
+        <div className="space-y-3">
+          {assignments.map((a) => (
+            <div
+              key={a.id}
+              className="bg-white shadow rounded-lg p-4 flex items-start justify-between gap-4"
+            >
+              <div className="flex-1">
+                <Link
+                  href={`/assignments/${a.id}`}
+                  className="font-medium text-gray-900 hover:text-brand-600"
+                >
+                  {a.description}
+                </Link>
+                <div className="mt-1 flex flex-wrap gap-2 text-xs text-gray-500">
+                  <span
+                    className={`inline-block rounded-full px-2 py-0.5 font-medium ${STATUS_COLORS[a.status]}`}
+                  >
+                    {STATUS_LABELS[a.status]}
+                  </span>
+                  {a.delivery_destination && (
+                    <span>{DESTINATION_LABELS[a.delivery_destination]}</span>
+                  )}
+                  {a.due_date && <span>Due: {new Date(a.due_date).toLocaleDateString()}</span>}
+                  {a.assigned_profile?.display_name && (
+                    <span>Assigned: {a.assigned_profile.display_name}</span>
+                  )}
+                </div>
+              </div>
+              {a.status === 'open' && !a.assigned_to && (
+                <button
+                  onClick={() => handleClaim(a.id)}
+                  className="rounded-md bg-brand-600 px-3 py-1.5 text-sm text-white hover:bg-brand-700"
+                >
+                  Claim
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/lib/assignments.ts
+++ b/src/lib/assignments.ts
@@ -1,0 +1,33 @@
+import type { AssignmentStatus, DeliveryDestination } from '@/types/database'
+
+export const DESTINATION_LABELS: Record<DeliveryDestination, string> = {
+  ruths_cottage: "Ruth's Cottage",
+  brother_charlies: "Brother Charlie's Rescue Mission",
+  bake_sale: 'Bake Sale',
+  individual: 'Individual',
+  other: 'Other',
+}
+
+export const STATUS_LABELS: Record<AssignmentStatus, string> = {
+  open: 'Open',
+  in_progress: 'In Progress',
+  completed: 'Completed',
+}
+
+export const STATUS_COLORS: Record<AssignmentStatus, string> = {
+  open: 'bg-blue-100 text-blue-800',
+  in_progress: 'bg-yellow-100 text-yellow-800',
+  completed: 'bg-green-100 text-green-800',
+}
+
+/**
+ * Validates a status transition.
+ * Allowed: open → in_progress, in_progress → completed, open → completed
+ */
+export function isValidStatusTransition(from: AssignmentStatus, to: AssignmentStatus): boolean {
+  if (from === to) return false
+  if (from === 'completed') return false
+  if (from === 'open' && (to === 'in_progress' || to === 'completed')) return true
+  if (from === 'in_progress' && to === 'completed') return true
+  return false
+}

--- a/tests/unit/api/assignments/id-route.test.ts
+++ b/tests/unit/api/assignments/id-route.test.ts
@@ -1,0 +1,161 @@
+import { NextRequest } from 'next/server'
+
+const mockSelect = jest.fn()
+const mockSingle = jest.fn()
+const mockUpdate = jest.fn()
+const mockDelete = jest.fn()
+const mockEq = jest.fn()
+const mockGetUser = jest.fn()
+
+const mockFrom = jest.fn(() => ({
+  select: mockSelect,
+  update: mockUpdate,
+  delete: mockDelete,
+}))
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(() =>
+    Promise.resolve({
+      from: mockFrom,
+      auth: { getUser: mockGetUser },
+    })
+  ),
+}))
+
+import { GET, PATCH, DELETE } from '@/app/api/assignments/[id]/route'
+
+function makeRequest(url: string, init?: RequestInit) {
+  return new NextRequest(new URL(url, 'http://localhost'), init as never)
+}
+
+const paramsPromise = (id: string) => Promise.resolve({ id })
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('GET /api/assignments/[id]', () => {
+  it('returns an assignment by id', async () => {
+    const assignment = { id: 'abc', description: 'Bake loaves', status: 'open' }
+    mockSelect.mockReturnValue({ eq: mockEq })
+    mockEq.mockReturnValue({ single: mockSingle })
+    mockSingle.mockResolvedValue({ data: assignment, error: null })
+
+    const res = await GET(makeRequest('http://localhost/api/assignments/abc'), {
+      params: paramsPromise('abc'),
+    })
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.description).toBe('Bake loaves')
+  })
+
+  it('returns 404 when not found', async () => {
+    mockSelect.mockReturnValue({ eq: mockEq })
+    mockEq.mockReturnValue({ single: mockSingle })
+    mockSingle.mockResolvedValue({ data: null, error: { message: 'Not found' } })
+
+    const res = await GET(makeRequest('http://localhost/api/assignments/bad'), {
+      params: paramsPromise('bad'),
+    })
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('PATCH /api/assignments/[id]', () => {
+  it('returns 401 when not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+
+    const res = await PATCH(
+      makeRequest('http://localhost/api/assignments/abc', {
+        method: 'PATCH',
+        body: JSON.stringify({ description: 'Updated' }),
+      }),
+      { params: paramsPromise('abc') }
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it('rejects invalid status transition', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+
+    // Mock the current status fetch
+    const statusSelect = jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({
+          data: { status: 'completed' },
+          error: null,
+        }),
+      }),
+    })
+    mockFrom.mockReturnValueOnce({ select: statusSelect, update: mockUpdate, delete: mockDelete })
+
+    const res = await PATCH(
+      makeRequest('http://localhost/api/assignments/abc', {
+        method: 'PATCH',
+        body: JSON.stringify({ status: 'open' }),
+      }),
+      { params: paramsPromise('abc') }
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.error).toContain('Cannot transition')
+  })
+
+  it('handles claim action', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockUpdate.mockReturnValue({ eq: mockEq })
+    mockEq.mockReturnValue({ select: mockSelect })
+    mockSelect.mockReturnValue({ single: mockSingle })
+    mockSingle.mockResolvedValue({
+      data: { id: 'abc', assigned_to: 'user-1', status: 'in_progress' },
+      error: null,
+    })
+
+    const res = await PATCH(
+      makeRequest('http://localhost/api/assignments/abc', {
+        method: 'PATCH',
+        body: JSON.stringify({ claim: true }),
+      }),
+      { params: paramsPromise('abc') }
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.assigned_to).toBe('user-1')
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assigned_to: 'user-1',
+        status: 'in_progress',
+      })
+    )
+  })
+})
+
+describe('DELETE /api/assignments/[id]', () => {
+  it('returns 401 when not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+
+    const res = await DELETE(
+      makeRequest('http://localhost/api/assignments/abc', { method: 'DELETE' }),
+      { params: paramsPromise('abc') }
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it('deletes an assignment', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockDelete.mockReturnValue({ eq: mockEq })
+    mockEq.mockResolvedValue({ error: null })
+
+    const res = await DELETE(
+      makeRequest('http://localhost/api/assignments/abc', { method: 'DELETE' }),
+      { params: paramsPromise('abc') }
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.success).toBe(true)
+  })
+})

--- a/tests/unit/api/assignments/route.test.ts
+++ b/tests/unit/api/assignments/route.test.ts
@@ -1,0 +1,168 @@
+import { NextRequest } from 'next/server'
+
+const mockSelect = jest.fn()
+const mockInsert = jest.fn()
+const mockOrder = jest.fn()
+const mockEq = jest.fn()
+const mockSingle = jest.fn()
+const mockGetUser = jest.fn()
+
+const mockFrom = jest.fn(() => ({
+  select: mockSelect,
+  insert: mockInsert,
+}))
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(() =>
+    Promise.resolve({
+      from: mockFrom,
+      auth: { getUser: mockGetUser },
+    })
+  ),
+}))
+
+import { GET, POST } from '@/app/api/assignments/route'
+
+function makeRequest(url: string, init?: RequestInit) {
+  return new NextRequest(new URL(url, 'http://localhost'), init as never)
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('GET /api/assignments', () => {
+  it('returns all assignments ordered by due_date', async () => {
+    const assignments = [{ id: '1', description: 'Bake loaves', status: 'open' }]
+    mockSelect.mockReturnValue({ order: mockOrder })
+    mockOrder.mockResolvedValue({ data: assignments, error: null })
+
+    const res = await GET(makeRequest('http://localhost/api/assignments'))
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toHaveLength(1)
+    expect(mockFrom).toHaveBeenCalledWith('assignments')
+  })
+
+  it('filters by status', async () => {
+    mockSelect.mockReturnValue({ order: mockOrder })
+    mockOrder.mockReturnValue({ eq: mockEq })
+    mockEq.mockResolvedValue({ data: [], error: null })
+
+    const res = await GET(makeRequest('http://localhost/api/assignments?status=open'))
+    expect(res.status).toBe(200)
+    expect(mockEq).toHaveBeenCalledWith('status', 'open')
+  })
+
+  it('filters by destination', async () => {
+    mockSelect.mockReturnValue({ order: mockOrder })
+    mockOrder.mockReturnValue({ eq: mockEq })
+    mockEq.mockResolvedValue({ data: [], error: null })
+
+    const res = await GET(makeRequest('http://localhost/api/assignments?destination=ruths_cottage'))
+    expect(res.status).toBe(200)
+    expect(mockEq).toHaveBeenCalledWith('delivery_destination', 'ruths_cottage')
+  })
+
+  it('filters by assignee', async () => {
+    mockSelect.mockReturnValue({ order: mockOrder })
+    mockOrder.mockReturnValue({ eq: mockEq })
+    mockEq.mockResolvedValue({ data: [], error: null })
+
+    const res = await GET(makeRequest('http://localhost/api/assignments?assignee=user-1'))
+    expect(res.status).toBe(200)
+    expect(mockEq).toHaveBeenCalledWith('assigned_to', 'user-1')
+  })
+
+  it('returns 500 on database error', async () => {
+    mockSelect.mockReturnValue({ order: mockOrder })
+    mockOrder.mockResolvedValue({ data: null, error: { message: 'DB error' } })
+
+    const res = await GET(makeRequest('http://localhost/api/assignments'))
+    expect(res.status).toBe(500)
+  })
+})
+
+describe('POST /api/assignments', () => {
+  it('returns 401 when not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+
+    const res = await POST(
+      makeRequest('http://localhost/api/assignments', {
+        method: 'POST',
+        body: JSON.stringify({ description: 'Test' }),
+      })
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 when description is missing', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+
+    const res = await POST(
+      makeRequest('http://localhost/api/assignments', {
+        method: 'POST',
+        body: JSON.stringify({}),
+      })
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('creates an assignment with status open when no assignee', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockInsert.mockReturnValue({ select: jest.fn().mockReturnValue({ single: mockSingle }) })
+    mockSingle.mockResolvedValue({
+      data: { id: 'new-1', description: 'Bake loaves', status: 'open' },
+      error: null,
+    })
+
+    const res = await POST(
+      makeRequest('http://localhost/api/assignments', {
+        method: 'POST',
+        body: JSON.stringify({
+          description: 'Bake loaves',
+          delivery_destination: 'ruths_cottage',
+        }),
+      })
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(201)
+    expect(body.status).toBe('open')
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: 'Bake loaves',
+        status: 'open',
+        created_by: 'user-1',
+      })
+    )
+  })
+
+  it('sets status to in_progress when assigned_to is provided', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockInsert.mockReturnValue({ select: jest.fn().mockReturnValue({ single: mockSingle }) })
+    mockSingle.mockResolvedValue({
+      data: { id: 'new-1', description: 'Bake', status: 'in_progress', assigned_to: 'user-1' },
+      error: null,
+    })
+
+    const res = await POST(
+      makeRequest('http://localhost/api/assignments', {
+        method: 'POST',
+        body: JSON.stringify({
+          description: 'Bake',
+          assigned_to: 'user-1',
+        }),
+      })
+    )
+
+    expect(res.status).toBe(201)
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'in_progress',
+        assigned_to: 'user-1',
+      })
+    )
+  })
+})

--- a/tests/unit/assignments/assignments.test.ts
+++ b/tests/unit/assignments/assignments.test.ts
@@ -1,0 +1,61 @@
+import {
+  DESTINATION_LABELS,
+  STATUS_LABELS,
+  STATUS_COLORS,
+  isValidStatusTransition,
+} from '@/lib/assignments'
+
+describe('DESTINATION_LABELS', () => {
+  it('has labels for all five destinations', () => {
+    expect(DESTINATION_LABELS.ruths_cottage).toBe("Ruth's Cottage")
+    expect(DESTINATION_LABELS.brother_charlies).toBe("Brother Charlie's Rescue Mission")
+    expect(DESTINATION_LABELS.bake_sale).toBe('Bake Sale')
+    expect(DESTINATION_LABELS.individual).toBe('Individual')
+    expect(DESTINATION_LABELS.other).toBe('Other')
+  })
+})
+
+describe('STATUS_LABELS', () => {
+  it('has labels for all three statuses', () => {
+    expect(STATUS_LABELS.open).toBe('Open')
+    expect(STATUS_LABELS.in_progress).toBe('In Progress')
+    expect(STATUS_LABELS.completed).toBe('Completed')
+  })
+})
+
+describe('STATUS_COLORS', () => {
+  it('has colors for all three statuses', () => {
+    expect(STATUS_COLORS.open).toContain('blue')
+    expect(STATUS_COLORS.in_progress).toContain('yellow')
+    expect(STATUS_COLORS.completed).toContain('green')
+  })
+})
+
+describe('isValidStatusTransition', () => {
+  it('allows open → in_progress', () => {
+    expect(isValidStatusTransition('open', 'in_progress')).toBe(true)
+  })
+
+  it('allows open → completed', () => {
+    expect(isValidStatusTransition('open', 'completed')).toBe(true)
+  })
+
+  it('allows in_progress → completed', () => {
+    expect(isValidStatusTransition('in_progress', 'completed')).toBe(true)
+  })
+
+  it('disallows same status', () => {
+    expect(isValidStatusTransition('open', 'open')).toBe(false)
+    expect(isValidStatusTransition('in_progress', 'in_progress')).toBe(false)
+    expect(isValidStatusTransition('completed', 'completed')).toBe(false)
+  })
+
+  it('disallows backward transitions from completed', () => {
+    expect(isValidStatusTransition('completed', 'open')).toBe(false)
+    expect(isValidStatusTransition('completed', 'in_progress')).toBe(false)
+  })
+
+  it('disallows in_progress → open', () => {
+    expect(isValidStatusTransition('in_progress', 'open')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- Assignment list with filters (status, destination, my assignments)
- Create assignment form with delivery destination and self-assign
- Assignment detail page with claim, start working, and mark complete actions
- Status transition validation (open -> in_progress -> completed, no backwards)
- Business logic in `src/lib/assignments.ts` with labels, colors, and validation
- Full CRUD API routes with claim support
- 25 unit tests for business logic and API routes

## Test plan
- [x] 133 unit tests pass (`npx jest`)
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] Prettier formatting verified
- [x] Next.js build succeeds

Closes #9