### PR TITLE
feat: announcements board with pinning and dashboard widget

### DIFF
--- a/src/app/announcements/[id]/page.tsx
+++ b/src/app/announcements/[id]/page.tsx
@@ -1,0 +1,109 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter, useParams } from 'next/navigation'
+import { useProfile } from '@/lib/hooks/use-profile'
+import CommentSection from '@/components/CommentSection'
+
+interface AnnouncementDetail {
+  id: string
+  title: string
+  body: string
+  pinned: boolean
+  author_id: string | null
+  created_at: string
+  author: { display_name: string } | null
+}
+
+export default function AnnouncementDetailPage() {
+  const router = useRouter()
+  const params = useParams()
+  const id = params.id as string
+  const { profile, isAdmin } = useProfile()
+  const [announcement, setAnnouncement] = useState<AnnouncementDetail | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    async function fetchAnnouncement() {
+      const res = await fetch(`/api/announcements/${id}`)
+      if (res.ok) setAnnouncement(await res.json())
+      setLoading(false)
+    }
+    fetchAnnouncement()
+  }, [id])
+
+  async function handleDelete() {
+    if (!confirm('Delete this announcement?')) return
+    const res = await fetch(`/api/announcements/${id}`, { method: 'DELETE' })
+    if (res.ok) router.push('/announcements')
+  }
+
+  async function handleTogglePin() {
+    if (!announcement) return
+    const res = await fetch(`/api/announcements/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pinned: !announcement.pinned }),
+    })
+    if (res.ok) {
+      setAnnouncement((prev) => (prev ? { ...prev, pinned: !prev.pinned } : prev))
+    }
+  }
+
+  if (loading) return <div className="animate-pulse text-gray-400">Loading...</div>
+  if (!announcement) return <div className="text-red-600">Announcement not found.</div>
+
+  const canDelete = isAdmin || announcement.author_id === profile?.id
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <h1 className="text-2xl font-bold text-gray-900">{announcement.title}</h1>
+          {announcement.pinned && (
+            <span className="inline-block rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800">
+              Pinned
+            </span>
+          )}
+        </div>
+        <div className="flex gap-2">
+          {isAdmin && (
+            <button
+              onClick={handleTogglePin}
+              className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50"
+            >
+              {announcement.pinned ? 'Unpin' : 'Pin'}
+            </button>
+          )}
+          {canDelete && (
+            <button
+              onClick={handleDelete}
+              className="rounded-md border border-red-300 px-3 py-1.5 text-sm text-red-600 hover:bg-red-50"
+            >
+              Delete
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="bg-white shadow rounded-lg p-6">
+        <p className="text-sm text-gray-500 mb-4">
+          {announcement.author?.display_name && `${announcement.author.display_name} · `}
+          {new Date(announcement.created_at).toLocaleDateString()}
+        </p>
+        <div className="prose prose-sm text-gray-700 whitespace-pre-wrap">{announcement.body}</div>
+      </div>
+
+      <div className="bg-white shadow rounded-lg p-6">
+        <CommentSection parentType="announcement" parentId={id} />
+      </div>
+
+      <button
+        onClick={() => router.push('/announcements')}
+        className="text-sm text-brand-600 hover:underline"
+      >
+        &larr; Back to Announcements
+      </button>
+    </div>
+  )
+}

--- a/src/app/announcements/new/page.tsx
+++ b/src/app/announcements/new/page.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useProfile } from '@/lib/hooks/use-profile'
+
+export default function NewAnnouncementPage() {
+  const router = useRouter()
+  const { isAdmin } = useProfile()
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setLoading(true)
+    setError('')
+
+    const form = new FormData(e.currentTarget)
+    const body = {
+      title: form.get('title'),
+      body: form.get('body'),
+      pinned: form.get('pinned') === 'on',
+    }
+
+    const res = await fetch('/api/announcements', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+
+    if (res.ok) {
+      router.push('/announcements')
+    } else {
+      const data = await res.json()
+      setError(data.error || 'Failed to create announcement')
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="max-w-lg mx-auto">
+      <h1 className="text-2xl font-bold text-gray-900 mb-6">New Announcement</h1>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label htmlFor="title" className="block text-sm font-medium text-gray-700">
+            Title
+          </label>
+          <input
+            id="title"
+            name="title"
+            type="text"
+            required
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-brand-500 focus:ring-brand-500 sm:text-sm"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="body" className="block text-sm font-medium text-gray-700">
+            Message
+          </label>
+          <textarea
+            id="body"
+            name="body"
+            required
+            rows={6}
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-brand-500 focus:ring-brand-500 sm:text-sm"
+          />
+        </div>
+
+        {isAdmin && (
+          <label className="flex items-center gap-2 text-sm text-gray-700">
+            <input type="checkbox" name="pinned" className="rounded border-gray-300" />
+            Pin this announcement
+          </label>
+        )}
+
+        {error && (
+          <div className="rounded-md bg-red-50 p-3">
+            <p className="text-sm text-red-700">{error}</p>
+          </div>
+        )}
+
+        <div className="flex gap-3">
+          <button
+            type="submit"
+            disabled={loading}
+            className="rounded-md bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700 disabled:opacity-50"
+          >
+            {loading ? 'Posting...' : 'Post Announcement'}
+          </button>
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/src/app/announcements/page.tsx
+++ b/src/app/announcements/page.tsx
@@ -1,8 +1,73 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+
+interface Announcement {
+  id: string
+  title: string
+  body: string
+  pinned: boolean
+  created_at: string
+  author: { display_name: string } | null
+}
+
 export default function AnnouncementsPage() {
+  const [announcements, setAnnouncements] = useState<Announcement[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    async function fetchAnnouncements() {
+      const res = await fetch('/api/announcements')
+      if (res.ok) setAnnouncements(await res.json())
+      setLoading(false)
+    }
+    fetchAnnouncements()
+  }, [])
+
   return (
-    <div>
-      <h1 className="text-2xl font-bold text-gray-900 mb-4">Announcements</h1>
-      <p className="text-gray-600">Ministry announcements and updates coming soon.</p>
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900">Announcements</h1>
+        <Link
+          href="/announcements/new"
+          className="rounded-md bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700"
+        >
+          New Announcement
+        </Link>
+      </div>
+
+      {loading ? (
+        <div className="animate-pulse text-gray-400">Loading...</div>
+      ) : announcements.length === 0 ? (
+        <p className="text-gray-500 text-center py-8">No announcements yet.</p>
+      ) : (
+        <div className="space-y-3">
+          {announcements.map((a) => (
+            <Link
+              key={a.id}
+              href={`/announcements/${a.id}`}
+              className="block bg-white shadow rounded-lg p-4 hover:shadow-md transition-shadow"
+            >
+              <div className="flex items-start gap-2">
+                {a.pinned && (
+                  <span className="inline-block rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800">
+                    Pinned
+                  </span>
+                )}
+                <div className="flex-1">
+                  <h2 className="font-semibold text-gray-900">{a.title}</h2>
+                  <p className="mt-1 text-sm text-gray-600 line-clamp-2">{a.body}</p>
+                  <p className="mt-2 text-xs text-gray-400">
+                    {a.author?.display_name && `${a.author.display_name} · `}
+                    {new Date(a.created_at).toLocaleDateString()}
+                  </p>
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/app/api/announcements/[id]/route.ts
+++ b/src/app/api/announcements/[id]/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from('announcements')
+    .select('*, author:author_id(display_name)')
+    .eq('id', id)
+    .single()
+  if (error) return NextResponse.json({ error: error.message }, { status: 404 })
+  return NextResponse.json(data)
+}
+
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { data: profile } = (await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()) as unknown as { data: { role: string } | null }
+  const isAdmin = profile?.role === 'admin'
+
+  const body = await request.json()
+  const updates: Record<string, unknown> = {}
+
+  for (const key of ['title', 'body']) {
+    if (body[key] !== undefined) updates[key] = body[key]
+  }
+
+  // Only admin can toggle pin
+  if (body.pinned !== undefined) {
+    if (!isAdmin) {
+      return NextResponse.json({ error: 'Only admins can pin announcements' }, { status: 403 })
+    }
+    updates.pinned = body.pinned
+  }
+
+  const query = supabase.from('announcements')
+  // @ts-expect-error -- Supabase v2.98 generic inference
+  const { data, error } = await query.update(updates).eq('id', id).select().single()
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data)
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { error } = await supabase.from('announcements').delete().eq('id', id)
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/announcements/route.ts
+++ b/src/app/api/announcements/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import type { TablesInsert } from '@/types/database'
+
+export async function GET() {
+  const supabase = await createClient()
+
+  const { data, error } = await supabase
+    .from('announcements')
+    .select('*, author:author_id(display_name)')
+    .order('pinned', { ascending: false })
+    .order('created_at', { ascending: false })
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data)
+}
+
+export async function POST(request: NextRequest) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const body = await request.json()
+  const { title, body: announcementBody, pinned } = body
+
+  if (!title || !announcementBody) {
+    return NextResponse.json({ error: 'Title and body are required' }, { status: 400 })
+  }
+
+  // Only admin can pin
+  let isPinned = false
+  if (pinned) {
+    const { data: profile } = (await supabase
+      .from('profiles')
+      .select('role')
+      .eq('id', user.id)
+      .single()) as unknown as { data: { role: string } | null }
+    isPinned = profile?.role === 'admin'
+  }
+
+  const row: TablesInsert<'announcements'> = {
+    title,
+    body: announcementBody,
+    author_id: user.id,
+    pinned: isPinned,
+  }
+
+  const { data, error } = await supabase
+    .from('announcements')
+    // @ts-expect-error -- Supabase v2.98 generic inference
+    .insert(row)
+    .select('*, author:author_id(display_name)')
+    .single()
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data, { status: 201 })
+}

--- a/src/app/api/comments/[id]/route.ts
+++ b/src/app/api/comments/[id]/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  // Only author can edit
+  const { data: comment } = (await supabase
+    .from('comments')
+    .select('author_id')
+    .eq('id', id)
+    .single()) as unknown as { data: { author_id: string | null } | null }
+
+  if (!comment || comment.author_id !== user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const body = await request.json()
+  const query = supabase.from('comments')
+  // @ts-expect-error -- Supabase v2.98 generic inference
+  const { data, error } = await query.update({ body: body.body }).eq('id', id).select().single()
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data)
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  // Check if author or admin
+  const { data: comment } = (await supabase
+    .from('comments')
+    .select('author_id')
+    .eq('id', id)
+    .single()) as unknown as { data: { author_id: string | null } | null }
+
+  if (!comment) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+  const { data: profile } = (await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()) as unknown as { data: { role: string } | null }
+
+  const isAdmin = profile?.role === 'admin'
+  if (comment.author_id !== user.id && !isAdmin) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { error } = await supabase.from('comments').delete().eq('id', id)
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import type { TablesInsert } from '@/types/database'
+
+export async function GET(request: NextRequest) {
+  const supabase = await createClient()
+  const { searchParams } = new URL(request.url)
+  const parentType = searchParams.get('parentType')
+  const parentId = searchParams.get('parentId')
+
+  if (!parentType || !parentId) {
+    return NextResponse.json({ error: 'parentType and parentId are required' }, { status: 400 })
+  }
+
+  const { data, error } = await supabase
+    .from('comments')
+    .select('*, author:author_id(display_name)')
+    .eq('parent_type', parentType)
+    .eq('parent_id', parentId)
+    .order('created_at', { ascending: true })
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data)
+}
+
+export async function POST(request: NextRequest) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const body = await request.json()
+  const { parent_type, parent_id, body: commentBody } = body
+
+  if (!parent_type || !parent_id || !commentBody) {
+    return NextResponse.json(
+      { error: 'parent_type, parent_id, and body are required' },
+      { status: 400 }
+    )
+  }
+
+  const row: TablesInsert<'comments'> = {
+    parent_type,
+    parent_id,
+    body: commentBody,
+    author_id: user.id,
+  }
+
+  const { data, error } = await supabase
+    .from('comments')
+    // @ts-expect-error -- Supabase v2.98 generic inference
+    .insert(row)
+    .select('*, author:author_id(display_name)')
+    .single()
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data, { status: 201 })
+}

--- a/src/app/assignments/[id]/page.tsx
+++ b/src/app/assignments/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { useRouter, useParams } from 'next/navigation'
 import { useProfile } from '@/lib/hooks/use-profile'
+import CommentSection from '@/components/CommentSection'
 import {
   DESTINATION_LABELS,
   STATUS_LABELS,
@@ -163,6 +164,10 @@ export default function AssignmentDetailPage() {
             </button>
           )}
         </div>
+      </div>
+
+      <div className="bg-white shadow rounded-lg p-6">
+        <CommentSection parentType="assignment" parentId={id} />
       </div>
 
       <button

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,8 +1,90 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+
+interface Announcement {
+  id: string
+  title: string
+  body: string
+  pinned: boolean
+  created_at: string
+  author: { display_name: string } | null
+}
+
 export default function DashboardPage() {
+  const [announcements, setAnnouncements] = useState<Announcement[]>([])
+
+  useEffect(() => {
+    async function fetchLatest() {
+      const res = await fetch('/api/announcements')
+      if (res.ok) {
+        const data = await res.json()
+        setAnnouncements(data.slice(0, 3))
+      }
+    }
+    fetchLatest()
+  }, [])
+
   return (
-    <div>
-      <h1 className="text-2xl font-bold text-gray-900 mb-4">Dashboard</h1>
-      <p className="text-gray-600">Overview of ministry activity coming soon.</p>
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Link
+          href="/inventory"
+          className="bg-white shadow rounded-lg p-4 hover:shadow-md transition-shadow"
+        >
+          <h2 className="font-semibold text-gray-900">Inventory</h2>
+          <p className="text-sm text-gray-500 mt-1">Track bread, cookies, and baked goods</p>
+        </Link>
+        <Link
+          href="/assignments"
+          className="bg-white shadow rounded-lg p-4 hover:shadow-md transition-shadow"
+        >
+          <h2 className="font-semibold text-gray-900">Assignments</h2>
+          <p className="text-sm text-gray-500 mt-1">Baking tasks and deliveries</p>
+        </Link>
+        <Link
+          href="/recipes"
+          className="bg-white shadow rounded-lg p-4 hover:shadow-md transition-shadow"
+        >
+          <h2 className="font-semibold text-gray-900">Recipes</h2>
+          <p className="text-sm text-gray-500 mt-1">Ministry recipe collection</p>
+        </Link>
+      </div>
+
+      {announcements.length > 0 && (
+        <div>
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-lg font-semibold text-gray-900">Latest Announcements</h2>
+            <Link href="/announcements" className="text-sm text-brand-600 hover:underline">
+              View all
+            </Link>
+          </div>
+          <div className="space-y-2">
+            {announcements.map((a) => (
+              <Link
+                key={a.id}
+                href={`/announcements/${a.id}`}
+                className="block bg-white shadow rounded-lg p-3 hover:shadow-md transition-shadow"
+              >
+                <div className="flex items-start gap-2">
+                  {a.pinned && (
+                    <span className="inline-block rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800">
+                      Pinned
+                    </span>
+                  )}
+                  <div>
+                    <h3 className="font-medium text-gray-900 text-sm">{a.title}</h3>
+                    <p className="text-xs text-gray-500 mt-0.5 line-clamp-1">{a.body}</p>
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/app/inventory/[id]/page.tsx
+++ b/src/app/inventory/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useParams } from 'next/navigation'
 import type { InventoryItem } from '@/types/database'
 import { CATEGORY_LABELS, getFreshnessStatus, FRESHNESS_COLORS } from '@/lib/inventory'
 import { useProfile } from '@/lib/hooks/use-profile'
+import CommentSection from '@/components/CommentSection'
 
 export default function InventoryDetailPage() {
   const router = useRouter()
@@ -125,6 +126,10 @@ export default function InventoryDetailPage() {
             </button>
           </div>
         </div>
+      </div>
+
+      <div className="bg-white shadow rounded-lg p-6">
+        <CommentSection parentType="inventory_item" parentId={id} />
       </div>
 
       <button

--- a/src/app/recipes/[id]/page.tsx
+++ b/src/app/recipes/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { useRouter, useParams } from 'next/navigation'
 import { useProfile } from '@/lib/hooks/use-profile'
+import CommentSection from '@/components/CommentSection'
 
 interface RecipeDetail {
   id: string
@@ -89,6 +90,10 @@ export default function RecipeDetailPage() {
             </div>
           </div>
         )}
+      </div>
+
+      <div className="bg-white shadow rounded-lg p-6">
+        <CommentSection parentType="recipe" parentId={id} />
       </div>
 
       <button

--- a/src/components/CommentSection.tsx
+++ b/src/components/CommentSection.tsx
@@ -1,0 +1,184 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useProfile } from '@/lib/hooks/use-profile'
+import type { CommentParentType } from '@/types/database'
+
+interface Comment {
+  id: string
+  body: string
+  author_id: string | null
+  created_at: string
+  author: { display_name: string } | null
+}
+
+interface CommentSectionProps {
+  parentType: CommentParentType
+  parentId: string
+}
+
+function timeAgo(dateString: string): string {
+  const seconds = Math.floor((Date.now() - new Date(dateString).getTime()) / 1000)
+  if (seconds < 60) return 'just now'
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+}
+
+export default function CommentSection({ parentType, parentId }: CommentSectionProps) {
+  const { profile, isAdmin } = useProfile()
+  const [comments, setComments] = useState<Comment[]>([])
+  const [loading, setLoading] = useState(true)
+  const [newComment, setNewComment] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editBody, setEditBody] = useState('')
+
+  useEffect(() => {
+    async function fetchComments() {
+      const res = await fetch(`/api/comments?parentType=${parentType}&parentId=${parentId}`)
+      if (res.ok) setComments(await res.json())
+      setLoading(false)
+    }
+    fetchComments()
+  }, [parentType, parentId])
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!newComment.trim()) return
+    setSubmitting(true)
+
+    const res = await fetch('/api/comments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        parent_type: parentType,
+        parent_id: parentId,
+        body: newComment.trim(),
+      }),
+    })
+
+    if (res.ok) {
+      const comment = await res.json()
+      setComments((prev) => [...prev, comment])
+      setNewComment('')
+    }
+    setSubmitting(false)
+  }
+
+  async function handleEdit(id: string) {
+    if (!editBody.trim()) return
+    const res = await fetch(`/api/comments/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ body: editBody.trim() }),
+    })
+    if (res.ok) {
+      setComments((prev) => prev.map((c) => (c.id === id ? { ...c, body: editBody.trim() } : c)))
+      setEditingId(null)
+    }
+  }
+
+  async function handleDelete(id: string) {
+    if (!confirm('Delete this comment?')) return
+    const res = await fetch(`/api/comments/${id}`, { method: 'DELETE' })
+    if (res.ok) {
+      setComments((prev) => prev.filter((c) => c.id !== id))
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold text-gray-900">Comments</h3>
+
+      {loading ? (
+        <div className="animate-pulse text-gray-400 text-sm">Loading comments...</div>
+      ) : comments.length === 0 ? (
+        <p className="text-sm text-gray-500">No comments yet.</p>
+      ) : (
+        <div className="space-y-3">
+          {comments.map((comment) => (
+            <div key={comment.id} className="bg-gray-50 rounded-lg p-3">
+              <div className="flex items-center justify-between mb-1">
+                <span className="text-sm font-medium text-gray-900">
+                  {comment.author?.display_name || 'Unknown'}
+                </span>
+                <span className="text-xs text-gray-400">{timeAgo(comment.created_at)}</span>
+              </div>
+
+              {editingId === comment.id ? (
+                <div className="space-y-2">
+                  <textarea
+                    value={editBody}
+                    onChange={(e) => setEditBody(e.target.value)}
+                    rows={2}
+                    className="block w-full rounded border border-gray-300 px-2 py-1 text-sm"
+                  />
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => handleEdit(comment.id)}
+                      className="text-xs text-brand-600 hover:underline"
+                    >
+                      Save
+                    </button>
+                    <button
+                      onClick={() => setEditingId(null)}
+                      className="text-xs text-gray-500 hover:underline"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <p className="text-sm text-gray-700 whitespace-pre-wrap">{comment.body}</p>
+                  <div className="flex gap-2 mt-1">
+                    {comment.author_id === profile?.id && (
+                      <button
+                        onClick={() => {
+                          setEditingId(comment.id)
+                          setEditBody(comment.body)
+                        }}
+                        className="text-xs text-gray-500 hover:text-brand-600"
+                      >
+                        Edit
+                      </button>
+                    )}
+                    {(comment.author_id === profile?.id || isAdmin) && (
+                      <button
+                        onClick={() => handleDelete(comment.id)}
+                        className="text-xs text-gray-500 hover:text-red-600"
+                      >
+                        Delete
+                      </button>
+                    )}
+                  </div>
+                </>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="flex gap-2">
+        <input
+          type="text"
+          value={newComment}
+          onChange={(e) => setNewComment(e.target.value)}
+          placeholder="Add a comment..."
+          className="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-brand-500 focus:ring-brand-500"
+        />
+        <button
+          type="submit"
+          disabled={submitting || !newComment.trim()}
+          className="rounded-md bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700 disabled:opacity-50"
+        >
+          {submitting ? '...' : 'Post'}
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/tests/unit/api/announcements/id-route.test.ts
+++ b/tests/unit/api/announcements/id-route.test.ts
@@ -1,0 +1,173 @@
+import { NextRequest } from 'next/server'
+
+const mockSelect = jest.fn()
+const mockSingle = jest.fn()
+const mockUpdate = jest.fn()
+const mockDelete = jest.fn()
+const mockEq = jest.fn()
+const mockGetUser = jest.fn()
+
+const mockFrom = jest.fn(() => ({
+  select: mockSelect,
+  update: mockUpdate,
+  delete: mockDelete,
+}))
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(() =>
+    Promise.resolve({
+      from: mockFrom,
+      auth: { getUser: mockGetUser },
+    })
+  ),
+}))
+
+import { GET, PATCH, DELETE } from '@/app/api/announcements/[id]/route'
+
+function makeRequest(url: string, init?: RequestInit) {
+  return new NextRequest(new URL(url, 'http://localhost'), init as never)
+}
+
+const paramsPromise = (id: string) => Promise.resolve({ id })
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('GET /api/announcements/[id]', () => {
+  it('returns an announcement by id', async () => {
+    mockSelect.mockReturnValue({ eq: mockEq })
+    mockEq.mockReturnValue({ single: mockSingle })
+    mockSingle.mockResolvedValue({
+      data: { id: 'a1', title: 'Test', pinned: false },
+      error: null,
+    })
+
+    const res = await GET(makeRequest('http://localhost/api/announcements/a1'), {
+      params: paramsPromise('a1'),
+    })
+    expect(res.status).toBe(200)
+  })
+
+  it('returns 404 when not found', async () => {
+    mockSelect.mockReturnValue({ eq: mockEq })
+    mockEq.mockReturnValue({ single: mockSingle })
+    mockSingle.mockResolvedValue({ data: null, error: { message: 'Not found' } })
+
+    const res = await GET(makeRequest('http://localhost/api/announcements/bad'), {
+      params: paramsPromise('bad'),
+    })
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('PATCH /api/announcements/[id]', () => {
+  it('returns 401 when not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+
+    const res = await PATCH(
+      makeRequest('http://localhost/api/announcements/a1', {
+        method: 'PATCH',
+        body: JSON.stringify({ title: 'Updated' }),
+      }),
+      { params: paramsPromise('a1') }
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 when non-admin tries to pin', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+
+    // Profile fetch
+    const profileSelect = jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({
+          data: { role: 'baker' },
+          error: null,
+        }),
+      }),
+    })
+    mockFrom.mockReturnValueOnce({
+      select: profileSelect,
+      update: mockUpdate,
+      delete: mockDelete,
+    })
+
+    const res = await PATCH(
+      makeRequest('http://localhost/api/announcements/a1', {
+        method: 'PATCH',
+        body: JSON.stringify({ pinned: true }),
+      }),
+      { params: paramsPromise('a1') }
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it('allows admin to pin', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'admin-1' } } })
+
+    const profileSelect = jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({
+          data: { role: 'admin' },
+          error: null,
+        }),
+      }),
+    })
+    mockFrom
+      .mockReturnValueOnce({
+        select: profileSelect,
+        update: mockUpdate,
+        delete: mockDelete,
+      })
+      .mockReturnValueOnce({
+        select: mockSelect,
+        update: mockUpdate,
+        delete: mockDelete,
+      })
+
+    mockUpdate.mockReturnValue({ eq: mockEq })
+    mockEq.mockReturnValue({ select: mockSelect })
+    mockSelect.mockReturnValue({ single: mockSingle })
+    mockSingle.mockResolvedValue({
+      data: { id: 'a1', pinned: true },
+      error: null,
+    })
+
+    const res = await PATCH(
+      makeRequest('http://localhost/api/announcements/a1', {
+        method: 'PATCH',
+        body: JSON.stringify({ pinned: true }),
+      }),
+      { params: paramsPromise('a1') }
+    )
+    expect(res.status).toBe(200)
+  })
+})
+
+describe('DELETE /api/announcements/[id]', () => {
+  it('returns 401 when not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+
+    const res = await DELETE(
+      makeRequest('http://localhost/api/announcements/a1', { method: 'DELETE' }),
+      { params: paramsPromise('a1') }
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it('deletes an announcement', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockDelete.mockReturnValue({ eq: mockEq })
+    mockEq.mockResolvedValue({ error: null })
+
+    const res = await DELETE(
+      makeRequest('http://localhost/api/announcements/a1', { method: 'DELETE' }),
+      { params: paramsPromise('a1') }
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.success).toBe(true)
+  })
+})

--- a/tests/unit/api/announcements/route.test.ts
+++ b/tests/unit/api/announcements/route.test.ts
@@ -1,0 +1,142 @@
+import { NextRequest } from 'next/server'
+
+const mockSelect = jest.fn()
+const mockInsert = jest.fn()
+const mockOrder = jest.fn()
+const mockSingle = jest.fn()
+const mockEq = jest.fn()
+const mockGetUser = jest.fn()
+
+const mockFrom = jest.fn(() => ({
+  select: mockSelect,
+  insert: mockInsert,
+}))
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(() =>
+    Promise.resolve({
+      from: mockFrom,
+      auth: { getUser: mockGetUser },
+    })
+  ),
+}))
+
+import { GET, POST } from '@/app/api/announcements/route'
+
+function makeRequest(url: string, init?: RequestInit) {
+  return new NextRequest(new URL(url, 'http://localhost'), init as never)
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('GET /api/announcements', () => {
+  it('returns announcements sorted by pinned then date', async () => {
+    const announcements = [
+      { id: '1', title: 'Pinned', pinned: true },
+      { id: '2', title: 'Recent', pinned: false },
+    ]
+    const mockOrder2 = jest.fn()
+    mockSelect.mockReturnValue({ order: mockOrder })
+    mockOrder.mockReturnValue({ order: mockOrder2 })
+    mockOrder2.mockResolvedValue({ data: announcements, error: null })
+
+    const res = await GET()
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toHaveLength(2)
+    expect(mockOrder).toHaveBeenCalledWith('pinned', { ascending: false })
+    expect(mockOrder2).toHaveBeenCalledWith('created_at', { ascending: false })
+  })
+})
+
+describe('POST /api/announcements', () => {
+  it('returns 401 when not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+
+    const res = await POST(
+      makeRequest('http://localhost/api/announcements', {
+        method: 'POST',
+        body: JSON.stringify({ title: 'Test', body: 'Test body' }),
+      })
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 when title or body missing', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+
+    const res = await POST(
+      makeRequest('http://localhost/api/announcements', {
+        method: 'POST',
+        body: JSON.stringify({ title: 'No body' }),
+      })
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('creates announcement without pin for non-admin', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+
+    // First call: announcements table for insert
+    mockFrom.mockReturnValueOnce({ select: mockSelect, insert: mockInsert })
+    mockInsert.mockReturnValue({
+      select: jest.fn().mockReturnValue({ single: mockSingle }),
+    })
+    mockSingle.mockResolvedValue({
+      data: { id: '1', title: 'News', pinned: false },
+      error: null,
+    })
+
+    const res = await POST(
+      makeRequest('http://localhost/api/announcements', {
+        method: 'POST',
+        body: JSON.stringify({ title: 'News', body: 'Some news' }),
+      })
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(201)
+    expect(body.pinned).toBe(false)
+  })
+
+  it('allows admin to pin an announcement', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'admin-1' } } })
+
+    // Profile fetch for pin check
+    const profileSelect = jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({
+          data: { role: 'admin' },
+          error: null,
+        }),
+      }),
+    })
+    mockFrom
+      .mockReturnValueOnce({ select: profileSelect, insert: mockInsert })
+      .mockReturnValueOnce({ select: mockSelect, insert: mockInsert })
+
+    mockInsert.mockReturnValue({
+      select: jest.fn().mockReturnValue({ single: mockSingle }),
+    })
+    mockSingle.mockResolvedValue({
+      data: { id: '1', title: 'Urgent', pinned: true },
+      error: null,
+    })
+
+    const res = await POST(
+      makeRequest('http://localhost/api/announcements', {
+        method: 'POST',
+        body: JSON.stringify({ title: 'Urgent', body: 'Need loaves ASAP', pinned: true }),
+      })
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(201)
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ pinned: true })
+    )
+  })
+})

--- a/tests/unit/api/announcements/route.test.ts
+++ b/tests/unit/api/announcements/route.test.ts
@@ -135,8 +135,6 @@ describe('POST /api/announcements', () => {
     const body = await res.json()
 
     expect(res.status).toBe(201)
-    expect(mockInsert).toHaveBeenCalledWith(
-      expect.objectContaining({ pinned: true })
-    )
+    expect(mockInsert).toHaveBeenCalledWith(expect.objectContaining({ pinned: true }))
   })
 })

--- a/tests/unit/api/comments/id-route.test.ts
+++ b/tests/unit/api/comments/id-route.test.ts
@@ -1,0 +1,250 @@
+import { NextRequest } from 'next/server'
+
+const mockSelect = jest.fn()
+const mockSingle = jest.fn()
+const mockUpdate = jest.fn()
+const mockDelete = jest.fn()
+const mockEq = jest.fn()
+const mockGetUser = jest.fn()
+
+const mockFrom = jest.fn(() => ({
+  select: mockSelect,
+  update: mockUpdate,
+  delete: mockDelete,
+}))
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(() =>
+    Promise.resolve({
+      from: mockFrom,
+      auth: { getUser: mockGetUser },
+    })
+  ),
+}))
+
+import { PATCH, DELETE } from '@/app/api/comments/[id]/route'
+
+function makeRequest(url: string, init?: RequestInit) {
+  return new NextRequest(new URL(url, 'http://localhost'), init as never)
+}
+
+const paramsPromise = (id: string) => Promise.resolve({ id })
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('PATCH /api/comments/[id]', () => {
+  it('returns 401 when not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+
+    const res = await PATCH(
+      makeRequest('http://localhost/api/comments/c1', {
+        method: 'PATCH',
+        body: JSON.stringify({ body: 'updated' }),
+      }),
+      { params: paramsPromise('c1') }
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 when user is not the author', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-2' } } })
+
+    // Mock fetching the comment to check authorship
+    const commentSelect = jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({
+          data: { author_id: 'user-1' },
+          error: null,
+        }),
+      }),
+    })
+    mockFrom.mockReturnValueOnce({
+      select: commentSelect,
+      update: mockUpdate,
+      delete: mockDelete,
+    })
+
+    const res = await PATCH(
+      makeRequest('http://localhost/api/comments/c1', {
+        method: 'PATCH',
+        body: JSON.stringify({ body: 'updated' }),
+      }),
+      { params: paramsPromise('c1') }
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it('updates comment when user is the author', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+
+    // Mock fetching the comment
+    const commentSelect = jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({
+          data: { author_id: 'user-1' },
+          error: null,
+        }),
+      }),
+    })
+    mockFrom
+      .mockReturnValueOnce({
+        select: commentSelect,
+        update: mockUpdate,
+        delete: mockDelete,
+      })
+      .mockReturnValueOnce({
+        select: mockSelect,
+        update: mockUpdate,
+        delete: mockDelete,
+      })
+
+    mockUpdate.mockReturnValue({ eq: mockEq })
+    mockEq.mockReturnValue({ select: mockSelect })
+    mockSelect.mockReturnValue({ single: mockSingle })
+    mockSingle.mockResolvedValue({
+      data: { id: 'c1', body: 'updated text' },
+      error: null,
+    })
+
+    const res = await PATCH(
+      makeRequest('http://localhost/api/comments/c1', {
+        method: 'PATCH',
+        body: JSON.stringify({ body: 'updated text' }),
+      }),
+      { params: paramsPromise('c1') }
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.body).toBe('updated text')
+  })
+})
+
+describe('DELETE /api/comments/[id]', () => {
+  it('returns 401 when not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+
+    const res = await DELETE(
+      makeRequest('http://localhost/api/comments/c1', { method: 'DELETE' }),
+      { params: paramsPromise('c1') }
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 404 when comment not found', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+
+    const commentSelect = jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({ data: null, error: null }),
+      }),
+    })
+    mockFrom.mockReturnValueOnce({
+      select: commentSelect,
+      update: mockUpdate,
+      delete: mockDelete,
+    })
+
+    const res = await DELETE(
+      makeRequest('http://localhost/api/comments/c1', { method: 'DELETE' }),
+      { params: paramsPromise('c1') }
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 403 when not author and not admin', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-2' } } })
+
+    // Comment fetch
+    const commentSelect = jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({
+          data: { author_id: 'user-1' },
+          error: null,
+        }),
+      }),
+    })
+    // Profile fetch
+    const profileSelect = jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({
+          data: { role: 'baker' },
+          error: null,
+        }),
+      }),
+    })
+
+    mockFrom
+      .mockReturnValueOnce({
+        select: commentSelect,
+        update: mockUpdate,
+        delete: mockDelete,
+      })
+      .mockReturnValueOnce({
+        select: profileSelect,
+        update: mockUpdate,
+        delete: mockDelete,
+      })
+
+    const res = await DELETE(
+      makeRequest('http://localhost/api/comments/c1', { method: 'DELETE' }),
+      { params: paramsPromise('c1') }
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it('allows admin to delete any comment', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'admin-1' } } })
+
+    // Comment fetch
+    const commentSelect = jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({
+          data: { author_id: 'user-1' },
+          error: null,
+        }),
+      }),
+    })
+    // Profile fetch — admin
+    const profileSelect = jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({
+          data: { role: 'admin' },
+          error: null,
+        }),
+      }),
+    })
+    // Delete
+    const deleteMock = jest.fn().mockReturnValue({
+      eq: jest.fn().mockResolvedValue({ error: null }),
+    })
+
+    mockFrom
+      .mockReturnValueOnce({
+        select: commentSelect,
+        update: mockUpdate,
+        delete: deleteMock,
+      })
+      .mockReturnValueOnce({
+        select: profileSelect,
+        update: mockUpdate,
+        delete: deleteMock,
+      })
+      .mockReturnValueOnce({
+        select: mockSelect,
+        update: mockUpdate,
+        delete: deleteMock,
+      })
+
+    const res = await DELETE(
+      makeRequest('http://localhost/api/comments/c1', { method: 'DELETE' }),
+      { params: paramsPromise('c1') }
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.success).toBe(true)
+  })
+})

--- a/tests/unit/api/comments/route.test.ts
+++ b/tests/unit/api/comments/route.test.ts
@@ -1,0 +1,131 @@
+import { NextRequest } from 'next/server'
+
+const mockSelect = jest.fn()
+const mockInsert = jest.fn()
+const mockOrder = jest.fn()
+const mockEq = jest.fn()
+const mockSingle = jest.fn()
+const mockGetUser = jest.fn()
+
+const mockFrom = jest.fn(() => ({
+  select: mockSelect,
+  insert: mockInsert,
+}))
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(() =>
+    Promise.resolve({
+      from: mockFrom,
+      auth: { getUser: mockGetUser },
+    })
+  ),
+}))
+
+import { GET, POST } from '@/app/api/comments/route'
+
+function makeRequest(url: string, init?: RequestInit) {
+  return new NextRequest(new URL(url, 'http://localhost'), init as never)
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('GET /api/comments', () => {
+  it('returns 400 when parentType or parentId missing', async () => {
+    const res = await GET(makeRequest('http://localhost/api/comments'))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns comments filtered by parentType and parentId', async () => {
+    const comments = [{ id: '1', body: 'test', created_at: '2026-01-01' }]
+    const mockEq2 = jest.fn()
+    mockSelect.mockReturnValue({ eq: mockEq })
+    mockEq.mockReturnValue({ eq: mockEq2 })
+    mockEq2.mockReturnValue({ order: mockOrder })
+    mockOrder.mockResolvedValue({ data: comments, error: null })
+
+    const res = await GET(
+      makeRequest('http://localhost/api/comments?parentType=recipe&parentId=abc')
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toHaveLength(1)
+    expect(mockEq).toHaveBeenCalledWith('parent_type', 'recipe')
+    expect(mockEq2).toHaveBeenCalledWith('parent_id', 'abc')
+  })
+
+  it('returns 500 on database error', async () => {
+    const mockEq2 = jest.fn()
+    mockSelect.mockReturnValue({ eq: mockEq })
+    mockEq.mockReturnValue({ eq: mockEq2 })
+    mockEq2.mockReturnValue({ order: mockOrder })
+    mockOrder.mockResolvedValue({ data: null, error: { message: 'DB error' } })
+
+    const res = await GET(
+      makeRequest('http://localhost/api/comments?parentType=recipe&parentId=abc')
+    )
+    expect(res.status).toBe(500)
+  })
+})
+
+describe('POST /api/comments', () => {
+  it('returns 401 when not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+
+    const res = await POST(
+      makeRequest('http://localhost/api/comments', {
+        method: 'POST',
+        body: JSON.stringify({ parent_type: 'recipe', parent_id: 'abc', body: 'test' }),
+      })
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 when required fields missing', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+
+    const res = await POST(
+      makeRequest('http://localhost/api/comments', {
+        method: 'POST',
+        body: JSON.stringify({ parent_type: 'recipe' }),
+      })
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('creates a comment and returns 201', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockInsert.mockReturnValue({
+      select: jest.fn().mockReturnValue({ single: mockSingle }),
+    })
+    mockSingle.mockResolvedValue({
+      data: { id: 'c1', body: 'Great bread!', author_id: 'user-1' },
+      error: null,
+    })
+
+    const res = await POST(
+      makeRequest('http://localhost/api/comments', {
+        method: 'POST',
+        body: JSON.stringify({
+          parent_type: 'recipe',
+          parent_id: 'recipe-1',
+          body: 'Great bread!',
+        }),
+      })
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(201)
+    expect(body.body).toBe('Great bread!')
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parent_type: 'recipe',
+        parent_id: 'recipe-1',
+        body: 'Great bread!',
+        author_id: 'user-1',
+      })
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Announcements list page with pinned-first sorting
- Create announcement form (admin can pin)
- Announcement detail with pin/unpin toggle (admin only), delete, and comments
- Dashboard updated: quick-link cards for inventory/assignments/recipes + latest 3 announcements widget
- 12 unit tests for API routes including admin-only pin authorization

## Test plan
- [x] 158 unit tests pass (`npx jest`)
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] Prettier formatting verified
- [x] Next.js build succeeds

Closes #11